### PR TITLE
Update this extension to include ==

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,4 @@
-README.txt
+README.md
 setup.py
 MarkdownHighlight/__init__.py
 MarkdownHighlight/highlight.py

--- a/MarkdownHighlight/highlight.py
+++ b/MarkdownHighlight/highlight.py
@@ -7,7 +7,7 @@ from markdown.inlinepatterns import SimpleTagPattern
 from markdown.extensions import Extension
 
 # Global Vars
-MARK_RE =r'(\?{3}|-{3}|={2})(.*?)(\?{3}|_{3}|={2})'  
+MARK_RE =r'(\?{3}|={2})(.*?)(\?{3}|={2})'  
 
 class HighlightExtension(Extension):
     """Adds MARK_RE extension to Markdown class."""

--- a/MarkdownHighlight/highlight.py
+++ b/MarkdownHighlight/highlight.py
@@ -7,7 +7,7 @@ from markdown.inlinepatterns import SimpleTagPattern
 from markdown.extensions import Extension
 
 # Global Vars
-MARK_RE =r'(\={2})(.*?)(\={2})'  
+MARK_RE =r'(\?{3}|-{3}|={2})(.*?)(\?{3}|_{3}|={2})'  
 
 class HighlightExtension(Extension):
     """Adds MARK_RE extension to Markdown class."""

--- a/MarkdownHighlight/highlight.py
+++ b/MarkdownHighlight/highlight.py
@@ -1,13 +1,13 @@
 """Html Highlight extension for Markdown.
 
-Adds the possibility to use "??? something ???" or ___ something ___ to create a span that looks like <mark>something</mark>
+Adds the markdown "==something==" to create a span that looks like <mark>something</mark>
 """
 
 from markdown.inlinepatterns import SimpleTagPattern
 from markdown.extensions import Extension
 
 # Global Vars
-MARK_RE =r'(\?{3}|_{3})(.*?)(\?{3}|_{3})'  
+MARK_RE =r'(\={2})(.*?)(\={2})'  
 
 class HighlightExtension(Extension):
     """Adds MARK_RE extension to Markdown class."""

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 markdown.highlight
 ==================
 
-Adds the possibility to use ```==something==``` or ```??? something ???``` or ```___ something ___``` to create a span that looks like <mark>something</mark>
+Adds the possibility to use ```==something==``` or ```??? something ???``` to create a span that looks like <mark>something</mark>
 
 Install through pip:
 
@@ -19,3 +19,4 @@ result = markdown.markdown(textToRender, output_format="html5", extensions=[High
 ## Changelog
  - 2021.9.1 - updated readme from .txt to .md
  - 2021.9.1 - added ```==``` 
+ - The underscore ```___``` version creates italics and bold, removed.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 markdown.highlight
 ==================
 
-Adds the possibility to use "??? something ???" or "___ something ___" to create a span that looks like <mark>something</mark>
+Adds the possibility to use ```??? something ???``` or ```___ something ___``` to create a span that looks like <mark>something</mark>
 
 Install through pip:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adds the possibility to use ```??? something ???``` or ```___ something ___``` t
 
 Install through pip:
 
-$ pip install MarkdownHighlight
+```$ pip install MarkdownHighlight```
 
 To enable the MarkdownHighlight package and use it in your markdown generation just add it like so:
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ from MarkdownHighlight.highlight import HighlightExtension
 
 result = markdown.markdown(textToRender, output_format="html5", extensions=[HighlightExtension,]) )
 ```
+
+## Changelog
+ - 2021.9.1 - updated readme from .txt to .md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 markdown.highlight
 ==================
 
-Adds the possibility to use ```??? something ???``` or ```___ something ___``` to create a span that looks like <mark>something</mark>
+Adds the possibility to use ```==something==``` or ```??? something ???``` or ```___ something ___``` to create a span that looks like <mark>something</mark>
 
 Install through pip:
 
@@ -18,3 +18,4 @@ result = markdown.markdown(textToRender, output_format="html5", extensions=[High
 
 ## Changelog
  - 2021.9.1 - updated readme from .txt to .md
+ - 2021.9.1 - added ```==``` 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.3',
     packages=['MarkdownHighlight',],
     license='Apache License 2.0',
-    long_description=open('README.txt').read(),
+    long_description=open('README.md').read(),
     url='https://github.com/ribalba/markdown.highlight',
     description='A markdown extension that enables you to create <mark> tag by using ???some text???',
     author='Didi Hoffmann',

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from distutils.core import setup
 
 setup(
     name='MarkdownHighlight',
-    version='0.1.3',
+    version='0.1.4',
     packages=['MarkdownHighlight',],
     license='Apache License 2.0',
     long_description=open('README.md').read(),
     url='https://github.com/ribalba/markdown.highlight',
-    description='A markdown extension that enables you to create <mark> tag by using ???some text???',
+    description='A markdown extension that enables you to create <mark> tag by using ==some text== or ???some text???',
     author='Didi Hoffmann',
     author_email='didi@ribalba.de',
     install_requires=[


### PR DESCRIPTION
updated this extension to handle "==" to highlight as Typora, Obsidian, and others use this.  Supports "???" still.  Removed "___" as conflicts with bold/italic markdown.

Also, changed README.txt to README.md and updated it.